### PR TITLE
feat: multi-user support for Kubernetes deployment

### DIFF
--- a/docs/explanations/building-with-claude.md
+++ b/docs/explanations/building-with-claude.md
@@ -41,6 +41,7 @@ The specific files mentioned here are for Claude Code, but the same features are
 1. Create skills:
    - When you have spent effort working on a problem and have a solution, ask Claude to write a skill that captures the debugging methodology, not just the fix. This way you can reuse the same process for future problems.
    - See examples from this project in `.claude/skills/`
+   - Skills are only loaded when the agent sees that they might be needed (or you exlicity invoke with e.g. /build-robot). So they aren't taking up context space all the time, but they are there when you need them.
 1. Look after memory:
    - Claude Code has auto memory that is triggered on events like commits.
    - ask Claude to remember useful things at other time too.
@@ -59,6 +60,7 @@ The specific files mentioned here are for Claude Code, but the same features are
    - Checked into the repo, so every session and every contributor gets the same baseline.
    - Good for build commands, coding conventions, and constraints that Claude should always follow.
    - See this project's `CLAUDE.md` for an example.
+   - Keep it less than 40 lines or so as it is loaded into context at the start of every session.
 1. Give permission for effort and parallelism:
    - "Use as much effort as needed" and "make it multi-agent" unlock Claude's ability to work on multiple files simultaneously.
    - Without this, Claude tends to be conservative and sequential.

--- a/helm/robot-arm-sim/templates/deployment.yaml
+++ b/helm/robot-arm-sim/templates/deployment.yaml
@@ -18,8 +18,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: CLUSTER_MODE
+              value: "1"
           ports:
             - containerPort: {{ .Values.containerPort }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/robot-arm-sim/values.yaml
+++ b/helm/robot-arm-sim/values.yaml
@@ -10,3 +10,11 @@ service:
   port: 80
 
 containerPort: 8080
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: "2"
+    memory: 1Gi

--- a/src/robot_arm_sim/simulate/app/controls.py
+++ b/src/robot_arm_sim/simulate/app/controls.py
@@ -213,7 +213,8 @@ def _setup_state_restore(state: SimulatorState) -> None:
     async def _restore_state():
         raw = await ui.run_javascript(
             "var s = sessionStorage.getItem('reload_state');"
-            "sessionStorage.removeItem('reload_state');"
+            "if(s) sessionStorage.removeItem('reload_state');"
+            "else s = sessionStorage.getItem('sim_state');"
             "s"
         )
         if not raw:

--- a/src/robot_arm_sim/simulate/app/js_snippets.py
+++ b/src/robot_arm_sim/simulate/app/js_snippets.py
@@ -377,6 +377,66 @@ FACE_MARKER_INIT_JS = """
 """
 
 
+BEFOREUNLOAD_JS = """
+(function() {
+    window.__simJointAngles = {};
+    window.addEventListener('beforeunload', function() {
+        var appEl = document.getElementById('app');
+        if (!appEl || !appEl.__vue_app__) return;
+        var sc = null;
+        function walk(n, d) {
+            if (d > 30 || sc) return;
+            if (n.component) {
+                var p = n.component.proxy;
+                if (p && p.renderer && p.scene && p.controls) {
+                    sc = p; return;
+                }
+                if (n.component.subTree)
+                    walk(n.component.subTree, d+1);
+            }
+            if (Array.isArray(n.children))
+                n.children.forEach(function(c) {
+                    if (c && typeof c === 'object')
+                        walk(c, d+1);
+                });
+        }
+        walk(
+            appEl.__vue_app__._container._vnode,
+            0
+        );
+        var cam = null;
+        if (sc) {
+            var c = sc.camera;
+            var t = sc.controls;
+            cam = {
+                px: c.position.x,
+                py: c.position.y,
+                pz: c.position.z,
+                tx: t.target.x,
+                ty: t.target.y,
+                tz: t.target.z,
+                ux: c.up.x,
+                uy: c.up.y,
+                uz: c.up.z,
+                isOrtho: !!c.isOrthographicCamera,
+                left: c.left,
+                right: c.right,
+                top: c.top,
+                bottom: c.bottom
+            };
+        }
+        sessionStorage.setItem(
+            'sim_state',
+            JSON.stringify({
+                joints: window.__simJointAngles,
+                camera: cam
+            })
+        );
+    });
+})();
+"""
+
+
 SCENE_RESIZE_JS = """
 (function() {
     const appEl = document.getElementById('app');

--- a/src/robot_arm_sim/simulate/app/main.py
+++ b/src/robot_arm_sim/simulate/app/main.py
@@ -9,6 +9,7 @@ from nicegui import app, ui
 from ..urdf_loader import load_urdf
 from .controls import build_controls_panel
 from .edit_bores import build_edit_bores
+from .js_snippets import BEFOREUNLOAD_JS
 from .scene_objects import build_scene
 from .state import SimulatorState
 from .toolbar import build_toolbar, build_visibility_section
@@ -116,3 +117,6 @@ def _build_ui(robots: dict[str, Path], current_name: str) -> None:
         ):
             build_controls_panel(state)
             build_visibility_section(state)
+
+    # Register beforeunload handler for state persistence
+    ui.run_javascript(BEFOREUNLOAD_JS)

--- a/src/robot_arm_sim/simulate/app/scene_update.py
+++ b/src/robot_arm_sim/simulate/app/scene_update.py
@@ -33,6 +33,10 @@ def update_scene(state: SimulatorState) -> None:
 
     transforms = forward_kinematics(state.robot, state.joint_angles)
 
+    # Sync joint angles to JS for beforeunload persistence
+    angles_json = json.dumps(state.joint_angles)
+    ui.run_javascript(f"window.__simJointAngles={angles_json}")
+
     joint_positions: dict[str, tuple[float, ...]] = {}
     link_center_positions: dict[str, tuple[float, ...]] = {}
     visual_transforms: dict[str, np.ndarray] = {}

--- a/src/robot_arm_sim/simulate/app/toolbar.py
+++ b/src/robot_arm_sim/simulate/app/toolbar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,10 @@ from .js_snippets import SCREENSHOT_JS
 
 if TYPE_CHECKING:
     from .state import SimulatorState
+
+_CLUSTER_MODE = bool(
+    os.environ.get("CLUSTER_MODE") or os.environ.get("KUBERNETES_SERVICE_HOST")
+)
 
 
 def _apply_toggle_style(btn, active: bool) -> None:
@@ -25,33 +30,41 @@ def _apply_toggle_style(btn, active: bool) -> None:
 def build_toolbar(state: SimulatorState) -> None:
     """Build the toolbar below the 3D viewport."""
 
-    def shutdown():
-        import asyncio
-        import os
-        import signal
+    stop_dialog = None
+    if not _CLUSTER_MODE:
 
-        async def _delayed_kill():
-            await asyncio.sleep(0.5)
-            os.kill(os.getpid(), signal.SIGTERM)
+        def shutdown():
+            import asyncio
+            import os
+            import signal
 
-        ui.run_javascript(
-            "document.querySelector('#app').__vue_app__.unmount();"
-            "document.body.innerHTML = '<div style=\""
-            "display:flex;flex-direction:column;align-items:center;"
-            "justify-content:center;height:100vh;gap:16px;font-family:sans-serif"
-            '">'
-            '<span style="font-size:64px">&#x1f44b;</span>'
-            "<h1>Simulator stopped</h1>"
-            '<p style="color:#888">Run the simulate command again to restart.'
-            "</p></div>';"
-        )
-        asyncio.get_event_loop().create_task(_delayed_kill())
+            async def _delayed_kill():
+                await asyncio.sleep(0.5)
+                os.kill(os.getpid(), signal.SIGTERM)
 
-    with ui.dialog() as stop_dialog, ui.card():
-        ui.label("Are you sure you want to stop the simulator?")
-        with ui.row().classes("w-full justify-end"):
-            ui.button("Cancel", on_click=stop_dialog.close).props("flat")
-            ui.button("Stop", on_click=shutdown).props("color=red")
+            ui.run_javascript(
+                "document.querySelector('#app').__vue_app__.unmount();"
+                "document.body.innerHTML = '<div style=\""
+                "display:flex;flex-direction:column;"
+                "align-items:center;"
+                "justify-content:center;height:100vh;"
+                "gap:16px;font-family:sans-serif"
+                '">'
+                '<span style="font-size:64px">'
+                "&#x1f44b;</span>"
+                "<h1>Simulator stopped</h1>"
+                '<p style="color:#888">'
+                "Run the simulate command again"
+                " to restart."
+                "</p></div>';"
+            )
+            asyncio.get_event_loop().create_task(_delayed_kill())
+
+        with ui.dialog() as stop_dialog, ui.card():
+            ui.label("Are you sure you want to stop the simulator?")
+            with ui.row().classes("w-full justify-end"):
+                ui.button("Cancel", on_click=stop_dialog.close).props("flat")
+                ui.button("Stop", on_click=shutdown).props("color=red")
 
     docs_url = "https://gilesknap.github.io/robot-arm-sim"
     story_url = f"{docs_url}/main/explanations/building-with-claude.html"
@@ -161,9 +174,11 @@ def build_toolbar(state: SimulatorState) -> None:
             on_click=lambda: state.reset_all(),
         ).props("dense color=orange-7")
 
-        ui.button("Stop Simulator", on_click=stop_dialog.open).props(
-            "color=red-7 flat dense"
-        )
+        if stop_dialog:
+            sd = stop_dialog
+            ui.button("Stop Simulator", on_click=sd.open).props(
+                "color=red-7 flat dense"
+            )
 
         ui.space()
 


### PR DESCRIPTION
## Summary

- **Stop button hidden in cluster mode**: Detects `CLUSTER_MODE` or `KUBERNETES_SERVICE_HOST` env vars to prevent one user killing the server for everyone
- **Helm chart resource limits**: Added CPU/memory requests and limits, plus `CLUSTER_MODE=1` env var
- **State persistence**: Save joint angles + camera to `sessionStorage` on page unload so state survives refreshes and pod restarts
- **Docs**: Minor additions to the building-with-claude guide (skills loading, CLAUDE.md size guidance)

## Test plan

- [ ] Start simulator (`uv run robot-arm-sim simulate robots/UR5/`)
- [ ] Open two tabs — verify independent joint angles per client
- [ ] Move sliders, refresh page — verify state restores from sessionStorage
- [ ] Set `CLUSTER_MODE=1` — verify stop button is hidden
- [ ] `uv run tox -p` passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)