### PR TITLE
fix: tidy centering dropdown and add about dialog description

### DIFF
--- a/src/robot_arm_sim/simulate/app/edit_bores.py
+++ b/src/robot_arm_sim/simulate/app/edit_bores.py
@@ -51,19 +51,11 @@ def build_edit_bores(state: SimulatorState) -> None:
             "surface": "Surface",
             "center": "Center",
         }
-        centering_select = (
-            ui.select(
-                centering_options,
-                value="surface_bbox",
-                label="Centering",
-            )
-            .props("dense options-dense style='min-width: 130px;'")
-            .tooltip(
-                "Surface BBox: bore on face, use bounding box (default)\n"
-                "Surface: bore on face, use opposite flat face\n"
-                "Center: marker already at bore center"
-            )
-        )
+        ui.label("Centering").style("font-size: 0.85rem; line-height: 2;")
+        centering_select = ui.select(
+            centering_options,
+            value="surface_bbox",
+        ).props("dense options-dense borderless style='min-width: 110px;'")
 
         def _on_centering(e: Any) -> None:
             state.bore_centering["value"] = e.value

--- a/src/robot_arm_sim/simulate/app/toolbar.py
+++ b/src/robot_arm_sim/simulate/app/toolbar.py
@@ -74,6 +74,12 @@ def build_toolbar(state: SimulatorState) -> None:
         ui.card().style("max-width: 480px; text-align: left"),
     ):
         ui.label("About Robot Arm Simulator").classes("text-h6")
+        ui.label(
+            "Automatically generates interactive robot simulations from"
+            " STL mesh files. Powered by Claude Code and Python, it infers"
+            " part connections, derives the kinematics, and builds a"
+            " fully articulated 3D simulator."
+        ).style("color: #555; font-size: 0.9rem; line-height: 1.4;")
         ui.label("Toolbar buttons").classes("text-subtitle2")
         _bdr = "border: 1px solid rgba(0,0,0,0.12);"
         _th = f"text-align: left; padding: 6px 8px; {_bdr}"


### PR DESCRIPTION
## Summary

- Move centering label inline next to dropdown, remove tooltip popup, use borderless style for cleaner look
- Add project description text to the about dialog

## Test plan

- [ ] Edit Bores centering dropdown displays cleanly inline
- [ ] About dialog shows description text under the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)