### PR TITLE
feat: show version in About dialog and always pull latest image

### DIFF
--- a/helm/robot-arm-sim/values.yaml
+++ b/helm/robot-arm-sim/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/gilesknap/robot-arm-sim
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 service:
   type: ClusterIP

--- a/src/robot_arm_sim/simulate/app/toolbar.py
+++ b/src/robot_arm_sim/simulate/app/toolbar.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 from nicegui import ui
 
+from robot_arm_sim import __version__
+
 from .js_snippets import SCREENSHOT_JS
 
 if TYPE_CHECKING:
@@ -74,6 +76,7 @@ def build_toolbar(state: SimulatorState) -> None:
         ui.card().style("max-width: 480px; text-align: left"),
     ):
         ui.label("About Robot Arm Simulator").classes("text-h6")
+        ui.label(f"Version {__version__}").style("color: #888; font-size: 0.8rem;")
         ui.label(
             "Automatically generates interactive robot simulations from"
             " STL mesh files. Powered by Claude Code and Python, it infers"


### PR DESCRIPTION
## Summary
- Display the package version (`setuptools_scm`) in the About dialog
- Change Helm `imagePullPolicy` from `IfNotPresent` to `Always` so the `latest` tag always fetches the newest build

## Test plan
- [ ] Open the simulator and click the About (info) button — verify version is shown
- [ ] Deploy with Helm and confirm the pod pulls the latest image on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)