### PR TITLE
feat: add build-chain command to automate chain.yaml scaffolding

### DIFF
--- a/.claude/skills/make-robot/03-build-chain.md
+++ b/.claude/skills/make-robot/03-build-chain.md
@@ -9,115 +9,69 @@ Combine analysis data and manufacturer specs to write `chain.yaml`.
 
 ## Steps
 
-### 1. Read Analysis Data
+### 1. Generate Draft Chain (automated)
 
-1. Read `summary.yaml` for part ordering and assembly hints
-2. Read each `<part>.yaml` for connection points, bore positions, axes
+Run the `build-chain` command to generate a scaffold `chain.yaml`:
 
-### 2. Determine Chain Topology
-
-- Sequential parts (A0, A1, ...) or semantic names (base, shoulder, ...) form a serial chain
-- For semantic names: determine order from geometry (base is flat/short), bounding box sizes, manufacturer docs
-- Combined parts (e.g., A3_4) span multiple joints — create a virtual link with `mesh: null`
-- Connection point axes suggest joint rotation axis at each interface
-
-### 3. Determine Joint Axes from Bore Detection
-
-Each joint's rotation axis comes from the **parent link's distal bore axis** — the
-bore where the child part physically attaches.
-
-1. For each joint, look up the parent link's analysis YAML
-2. Find the `distal` connection point → its `axis` field is the joint axis
-3. Cross-check: the child link's `proximal` bore axis should agree (same physical bore)
-4. If they disagree, prefer the **distal** axis (proximal detection can pick the wrong
-   cylinder on multi-axis parts like wrist segments)
-
-**Example — UR5:**
-| Parent link | Distal bore axis | Joint   | Axis        |
-|------------|-----------------|---------|-------------|
-| base       | [0, 0, 1]       | joint_1 | [0, 0, 1]   |
-| shoulder   | [0, 1, 0]       | joint_2 | [0, 1, 0]   |
-| upperarm   | [0, 1, 0]       | joint_3 | [0, 1, 0]   |
-| forearm    | [0, 1, 0]       | joint_4 | [0, 1, 0]   |
-| wrist1     | [0, 0, 1]       | joint_5 | [0, 0, 1]   |
-| wrist2     | [0, 1, 0]       | joint_6 | [0, 1, 0]   |
-
-### 4. Compute Joint Origins from DH Parameters
-
-**CRITICAL**: ALWAYS use explicit `origin` values from DH params. Bore-detected connection points are for validation only.
-
-#### Simple robots (all DH alpha = 0)
-All joints stack vertically at zero config:
-- joint_1 origin: `[0, 0, d1_base]` (base height in metres)
-- joint_2 origin: `[0, 0, remaining_d1]`
-- Subsequent joints: DH `a` and `d` as Z distances
-
-#### Robots with DH alpha rotations (e.g., UR5)
-Need `origin_rpy` and may have lateral offsets:
-1. Identify which joints have α ≠ 0
-2. For each α = ±π/2: add `origin_rpy` to that joint
-3. Origin values follow URDF convention — DH `a` and `d` go into different components depending on accumulated frame rotation
-
-**UR-family example:**
-```yaml
-# J1: origin [0, 0, d1/1000]
-# J2: origin [0, shoulder_offset/1000, 0], origin_rpy: [0, pi/2, 0]
-# J3: origin [0, elbow_offset/1000, a2/1000]
-# J4: origin [0, 0, a3/1000], origin_rpy: [0, pi/2, 0]
-# J5: origin [0, d4/1000, 0]  # may need origin_rpy if DH alpha5 ≠ 0
-# J6: origin [0, 0, d5/1000]
+```bash
+uv run python -m robot_arm_sim build-chain robots/<name> --dry-run
 ```
 
-### 5. Preserve User-Added Links
+This automates:
+- Part ordering (for numbered names like `link_0`, `link_1`, ...)
+- Joint axes from parent distal bore detection
+- Joint origins from connection points (proximal → distal distances)
+- Joint limits from specs.yaml (deg → rad conversion)
+- DH params dict for reference metadata
+- Cross-validation of distances against DH parameters
+- Preservation of existing user-added links
 
-If `chain.yaml` already exists, read it first and collect any links/joints with
-`user_added: true`.  After building the new chain from manufacturer data,
-**re-append** those user-added links and joints at the end — do not overwrite them.
-This preserves end-effectors and other custom parts across regeneration.
+When satisfied with the dry-run output, run without `--dry-run` to write `chain.yaml`.
 
-### 6. Write chain.yaml
+### 2. Review and Fix (LLM judgment required)
 
-```yaml
-robot_name: <Robot-Name>
-dh_params:  # from manufacturer specs (mm)
-  d1: ...
-  a2: ...
-  # shoulder_offset: ...  # if applicable
-  # elbow_offset: ...     # if applicable
+The `build-chain` output flags items marked **REVIEW** that need manual attention:
 
-links:
-  - name: base_link
-    mesh: <stl_stem>        # matches stl_files/<stem>.stl
-  - name: link_1
-    mesh: <stl_stem>
-  # ... one entry per link
-  # Virtual links: mesh: null
+#### Part ordering for semantic names
+If parts use semantic names (base, shoulder, forearm, ...) instead of numbered
+names, the script cannot auto-order them. Determine order from:
+- Geometry: base is flat/short, bounding box sizes increase along the chain
+- Role hints in `summary.yaml`
+- Manufacturer documentation
 
-joints:
-  - name: joint_1
-    type: revolute
-    parent: base_link
-    child: link_1
-    axis: [0, 0, 1]           # from parent's distal bore axis
-    limits: [-3.054, 3.054]   # from specs.yaml, in radians
-    origin: [0, 0, 0.093]    # ALWAYS explicit from DH params
-    # origin_rpy: [0, 1.5707963, 0]  # if DH alpha ≠ 0
-  - name: joint_2
-    type: revolute
-    parent: link_1
-    child: link_2
-    axis: [0, 1, 0]           # from parent's distal bore axis (pitch)
-    limits: [-3.054, 3.054]
-    origin: [0, 0.136, 0]
-    origin_rpy: [0, 1.5707963, 0]
-  # ... one entry per joint
-```
+#### Joint origins when connection points are missing
+When parts have no detected connection points, the script falls back to
+DH parameters with simple `[a/1000, 0, d/1000]` placement. This assumes
+vertical stacking and will be wrong for robots with DH alpha rotations.
+Fix the origin placement based on the robot's physical zero configuration.
 
-### 6. Cross-Validate
+#### origin_rpy for non-zero DH alpha
+Joints with DH α ≠ 0 need frame rotations. The script flags these but
+does not set `origin_rpy` because the correct mapping depends on the URDF
+frame convention chosen for this robot. Two valid approaches:
 
-Compare chain.yaml origins against bore-detected connection points:
-- If a joint origin differs from the detected bore by >10mm, investigate
-- The DH params should win, but large discrepancies suggest a problem
+1. **Use origin_rpy** (UR5 approach): Set `origin_rpy` on joints with α ≠ 0
+   and keep axes simple. Common pattern: `origin_rpy: [α_rad, 0, 0]`.
+2. **Fold into axes** (FANUC approach): No origin_rpy, but vary axis
+   directions (e.g. `[-1,0,0]`, `[0,-1,0]`) to match accumulated frame
+   rotations.
+
+Pick one approach consistently for the robot.
+
+#### Combined parts spanning multiple joints
+Parts like `A3_4` that span multiple joints need a virtual link with
+`mesh: null` inserted between them.
+
+#### Cross-validation warnings
+The script reports distance discrepancies between connection-point-derived
+origins and DH parameters. Differences >10mm should be investigated —
+the DH params should win, but large discrepancies may indicate wrong
+part ordering or incorrect connection point detection.
+
+### 3. Preserve User-Added Links
+
+The `build-chain` command automatically preserves links/joints with
+`user_added: true` from an existing `chain.yaml`. No manual action needed.
 
 ## Field Reference
 
@@ -144,3 +98,4 @@ Compare chain.yaml origins against bore-detected connection points:
 - All joints have explicit `origin` values
 - All joints have `limits` from manufacturer specs
 - Joint count matches DOF from specs.yaml
+- Cross-validation shows no unexplained >10mm discrepancies

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-robot-arm-sim provides three subcommands corresponding to the three pipeline
+robot-arm-sim provides four subcommands corresponding to the pipeline
 stages. Run any command with `--help` for built-in usage.
 
 ## Global options
@@ -40,6 +40,43 @@ $ robot-arm-sim analyze ROBOT_DIR [--override-manual]
 
 ```bash
 $ robot-arm-sim analyze robots/Meca500-R3/
+```
+
+---
+
+## `build-chain`
+
+Build a draft `chain.yaml` from `specs.yaml` and analysis data.
+
+```bash
+$ robot-arm-sim build-chain ROBOT_DIR [--output PATH] [--dry-run]
+```
+
+| Argument / Option | Description |
+|-------------------|-------------|
+| `ROBOT_DIR` | Path to robot directory. Must contain `specs.yaml` and `analysis/`. |
+| `--output PATH` | Output chain.yaml path. Default: `<ROBOT_DIR>/chain.yaml`. |
+| `--dry-run` | Print diagnostics without writing chain.yaml. |
+
+The command automates the deterministic parts of chain construction:
+
+- Part ordering for numbered naming (link_0, link_1, ...)
+- Joint axes from parent distal bore detection
+- Joint origins from connection points or DH parameter fallback
+- Joint limits converted from degrees to radians
+- DH params metadata dict
+- Cross-validation of connection-point distances against DH parameters
+- Preservation of user-added links from existing chain.yaml
+
+Items requiring manual review are flagged with **REVIEW** in the output:
+semantic part ordering, missing connection points, and non-zero DH alpha
+rotations that may need `origin_rpy`.
+
+**Example:**
+
+```bash
+$ robot-arm-sim build-chain robots/UR5/ --dry-run
+$ robot-arm-sim build-chain robots/FANUC-LRMate200iD/
 ```
 
 ---

--- a/src/robot_arm_sim/__main__.py
+++ b/src/robot_arm_sim/__main__.py
@@ -100,6 +100,44 @@ def generate(
     typer.echo("Done.")
 
 
+@app.command("build-chain")
+def build_chain(
+    robot_dir: Path = typer.Argument(
+        ...,
+        help="Path to robot directory (must contain specs.yaml and analysis/).",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+    ),
+    output: Path | None = typer.Option(
+        None,
+        help="Output chain.yaml path (default: <robot_dir>/chain.yaml).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print diagnostics without writing chain.yaml.",
+    ),
+) -> None:
+    """Build a draft chain.yaml from specs.yaml and analysis data."""
+    from .analyze.chain_builder import build_chain as _build_chain
+
+    typer.echo(f"Building chain for {robot_dir}...")
+    chain, messages = _build_chain(robot_dir)
+    for msg in messages:
+        typer.echo(msg)
+
+    if dry_run:
+        typer.echo("\nDry run — chain.yaml not written.")
+        return
+
+    output_path = output or (robot_dir / "chain.yaml")
+    from .models.models import save_chain_yaml
+
+    save_chain_yaml(chain, output_path)
+    typer.echo(f"\nWrote {output_path}")
+
+
 @app.command()
 def simulate(
     robots_dir: Path = typer.Argument(

--- a/src/robot_arm_sim/analyze/chain_builder.py
+++ b/src/robot_arm_sim/analyze/chain_builder.py
@@ -1,0 +1,357 @@
+"""Build a draft chain.yaml from specs.yaml and analysis data.
+
+Automates the deterministic parts of chain construction:
+- Part ordering from summary.yaml
+- Joint limits from specs.yaml (deg → rad)
+- Joint axes from bore detection (parent distal axis)
+- Joint origins from connection points (proximal → distal)
+- DH params dict for reference metadata
+- Cross-validation of connection-point distances against DH params
+- Preservation of user-added links from existing chain.yaml
+
+Parts that still require LLM review are flagged with warnings:
+- Joint origins when no connection points are available
+- Part ordering for semantic (non-numbered) names
+- origin_rpy for joints with non-zero DH alpha
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+from ..models.models import (
+    Chain,
+    ChainJoint,
+    ChainLink,
+    ConnectionPoint,
+    PartAnalysis,
+    load_chain_yaml,
+    load_part_yaml,
+    load_specs_yaml,
+    load_summary_yaml,
+)
+
+
+def _deg_to_rad(deg: float) -> float:
+    return round(deg * math.pi / 180, 4)
+
+
+def _mm_to_m(mm: float) -> float:
+    return round(mm / 1000, 6)
+
+
+def _extract_link_number(name: str) -> int | None:
+    """Extract numeric index from link names like 'link_2', 'A3', 'base_link'."""
+    if name in ("base", "base_link"):
+        return 0
+    m = re.search(r"(\d+)", name)
+    return int(m.group(1)) if m else None
+
+
+def _is_numbered_naming(part_names: list[str]) -> bool:
+    """Check if parts use numbered naming (link_0, A1, etc.)."""
+    nums = [_extract_link_number(n) for n in part_names]
+    return all(n is not None for n in nums)
+
+
+def _order_parts_numbered(part_names: list[str]) -> list[str]:
+    """Order parts by their numeric index."""
+    return sorted(part_names, key=lambda n: _extract_link_number(n) or 0)
+
+
+def _get_connection_point(analysis: PartAnalysis, end: str) -> ConnectionPoint | None:
+    """Get proximal or distal connection point from analysis."""
+    for cp in analysis.connection_points:
+        if cp.end == end:
+            return cp
+    return None
+
+
+def _build_dh_params_dict(specs_data: dict) -> dict[str, float]:
+    """Build the flat dh_params dict for chain.yaml from specs.yaml DH table."""
+    dh_list = specs_data.get("dh_params", [])
+    result: dict[str, float] = {}
+    for entry in dh_list:
+        joint_num = entry["joint"]
+        d = entry.get("d_mm", 0)
+        a = entry.get("a_mm", 0)
+        if abs(d) > 1e-6:
+            result[f"d{joint_num}"] = d
+        if abs(a) > 1e-6:
+            result[f"a{joint_num}"] = a
+    # Also include physical_offsets if present
+    offsets = specs_data.get("physical_offsets", {})
+    for key, val in offsets.items():
+        if key not in result and abs(val) > 1e-6:
+            result[key] = val
+    return result
+
+
+def _compute_origin_from_connections(
+    parent_analysis: PartAnalysis,
+    messages: list[str],
+    joint_name: str,
+) -> list[float] | None:
+    """Compute joint origin from parent's proximal→distal connection points.
+
+    Returns origin in metres, or None if connection points are missing.
+    """
+    proximal = _get_connection_point(parent_analysis, "proximal")
+    distal = _get_connection_point(parent_analysis, "distal")
+
+    if distal is None:
+        return None
+
+    if proximal is not None:
+        # Origin = distal - proximal (in parent mesh coords), converted to metres
+        origin = [_mm_to_m(distal.position[i] - proximal.position[i]) for i in range(3)]
+    else:
+        # No proximal — use distal position directly
+        origin = [_mm_to_m(distal.position[i]) for i in range(3)]
+
+    messages.append(f"  {joint_name}: origin from connection points = {origin}")
+    return origin
+
+
+def _compute_axis_from_connections(
+    parent_analysis: PartAnalysis,
+) -> list[float] | None:
+    """Get joint axis from parent's distal bore axis."""
+    distal = _get_connection_point(parent_analysis, "distal")
+    if distal is None:
+        return None
+    # Round to clean unit vectors
+    return [round(v, 4) for v in distal.axis]
+
+
+def _cross_validate_origins(
+    joints: list[ChainJoint],
+    dh_list: list[dict],
+    messages: list[str],
+) -> None:
+    """Compare connection-point-derived origins against DH parameter distances."""
+    if not dh_list:
+        return
+
+    messages.append("\nCross-validation (connection points vs DH params):")
+
+    for joint, dh in zip(joints, dh_list, strict=False):
+        if joint.origin is None:
+            continue
+
+        origin = joint.origin
+        dist_mm = math.sqrt(sum(v**2 for v in origin)) * 1000
+
+        # Expected distance from DH: sqrt(a² + d²)
+        d = abs(dh.get("d_mm", 0))
+        a = abs(dh.get("a_mm", 0))
+        expected_mm = math.sqrt(a**2 + d**2)
+
+        if expected_mm < 1e-6:
+            continue
+
+        diff = abs(dist_mm - expected_mm)
+        status = "OK" if diff < 10 else "REVIEW"
+        messages.append(
+            f"  {joint.name}: distance={dist_mm:.1f}mm,"
+            f" DH expected={expected_mm:.1f}mm,"
+            f" diff={diff:.1f}mm [{status}]"
+        )
+        if diff >= 10:
+            messages.append(
+                f"    WARNING: >10mm discrepancy — review origin for {joint.name}"
+            )
+
+
+def _flag_alpha_joints(
+    joints: list[ChainJoint],
+    dh_list: list[dict],
+    messages: list[str],
+) -> None:
+    """Flag joints that need origin_rpy due to non-zero DH alpha."""
+    for i, dh in enumerate(dh_list):
+        alpha = dh.get("alpha_deg", 0)
+        if abs(alpha) < 1e-6:
+            continue
+        if i < len(joints):
+            joint = joints[i]
+            alpha_rad = round(math.radians(alpha), 6)
+            messages.append(
+                f"\n  REVIEW: {joint.name} has DH alpha={alpha}deg"
+                f" ({alpha_rad} rad)."
+                f"\n    May need origin_rpy. Common pattern:"
+                f" origin_rpy=[{alpha_rad}, 0, 0]"
+                f"\n    The joint axis and origin placement may also"
+                f" need adjustment for this frame rotation."
+            )
+
+
+def build_chain(robot_dir: Path) -> tuple[Chain, list[str]]:
+    """Build a draft chain.yaml from specs.yaml and analysis data.
+
+    Returns the Chain model and diagnostic messages.
+    """
+    messages: list[str] = []
+    specs_path = robot_dir / "specs.yaml"
+    summary_path = robot_dir / "analysis" / "summary.yaml"
+    analysis_dir = robot_dir / "analysis"
+    existing_chain_path = robot_dir / "chain.yaml"
+
+    # --- Load inputs ---
+    if not specs_path.exists():
+        raise FileNotFoundError(f"specs.yaml not found at {specs_path}")
+    if not summary_path.exists():
+        raise FileNotFoundError(f"summary.yaml not found at {summary_path}")
+
+    load_specs_yaml(specs_path)  # validate schema
+    # Re-load raw for extra fields (Specs uses extra="allow")
+    import yaml
+
+    with open(specs_path) as f:
+        specs_raw = yaml.safe_load(f)
+
+    summary = load_summary_yaml(summary_path)
+    dof = specs_raw.get("dof", 6)
+    dh_list: list[dict] = specs_raw.get("dh_params", [])
+    joint_limits_list: list[dict] = specs_raw.get("joint_limits", [])
+
+    messages.append(f"Building chain for {summary.robot_name} (DOF={dof})")
+
+    # --- Load per-part analyses ---
+    analyses: dict[str, PartAnalysis] = {}
+    for part in summary.parts:
+        yaml_path = analysis_dir / part.file
+        if yaml_path.exists():
+            analyses[part.name] = load_part_yaml(yaml_path)
+
+    # --- Determine part ordering ---
+    part_names = [p.name for p in summary.parts]
+    if _is_numbered_naming(part_names):
+        ordered = _order_parts_numbered(part_names)
+        messages.append(f"Part ordering (numbered): {ordered}")
+    else:
+        # Semantic names — can't reliably order automatically
+        ordered = part_names
+        messages.append(
+            f"\n  REVIEW: Parts use semantic names: {part_names}"
+            f"\n    Cannot auto-order — please verify/reorder."
+            f"\n    Hint: look at bounding box sizes and role_hints in summary.yaml"
+        )
+
+    # --- Build DH params dict ---
+    dh_params_dict = _build_dh_params_dict(specs_raw)
+
+    # --- Build links ---
+    links: list[ChainLink] = []
+    for name in ordered:
+        links.append(ChainLink(name=name, mesh=name))
+
+    # --- Build joints ---
+    joints: list[ChainJoint] = []
+    n_joints = min(len(links) - 1, dof)
+
+    for i in range(n_joints):
+        parent = links[i]
+        child = links[i + 1]
+        joint_name = f"joint_{i + 1}"
+
+        # Joint limits from specs
+        limits: list[float] | None = None
+        if i < len(joint_limits_list):
+            jl = joint_limits_list[i]
+            limits = [
+                _deg_to_rad(jl.get("min_deg", -360)),
+                _deg_to_rad(jl.get("max_deg", 360)),
+            ]
+
+        # Joint axis from parent's distal bore
+        axis: list[float] = [0, 0, 1]  # default
+        parent_analysis = analyses.get(parent.name)
+        if parent_analysis:
+            detected_axis = _compute_axis_from_connections(parent_analysis)
+            if detected_axis:
+                axis = detected_axis
+                messages.append(
+                    f"  {joint_name}: axis from {parent.name} distal bore = {axis}"
+                )
+            else:
+                messages.append(
+                    f"  {joint_name}: no distal bore on {parent.name},"
+                    f" using default axis [0,0,1]"
+                )
+
+        # Joint origin from parent's connection points
+        origin: list[float] | None = None
+        if parent_analysis:
+            origin = _compute_origin_from_connections(
+                parent_analysis, messages, joint_name
+            )
+
+        if origin is None:
+            # Fall back: try to derive from DH params
+            if i < len(dh_list):
+                dh = dh_list[i]
+                d = dh.get("d_mm", 0)
+                a = dh.get("a_mm", 0)
+                # Simple vertical stacking — works for alpha=0 robots
+                origin = [_mm_to_m(a), 0, _mm_to_m(d)]
+                messages.append(
+                    f"  {joint_name}: origin from DH fallback [a={a}, d={d}] = {origin}"
+                )
+                messages.append(
+                    "    REVIEW: This assumes simple vertical stacking."
+                    " Check if DH alpha requires different axis placement."
+                )
+            else:
+                messages.append(f"  {joint_name}: WARNING — no origin data available!")
+
+        joints.append(
+            ChainJoint(
+                name=joint_name,
+                type="revolute",
+                parent=parent.name,
+                child=child.name,
+                axis=axis,
+                limits=limits,
+                origin=origin,
+            )
+        )
+
+    # --- Cross-validate ---
+    _cross_validate_origins(joints, dh_list, messages)
+
+    # --- Flag alpha rotations needing review ---
+    _flag_alpha_joints(joints, dh_list, messages)
+
+    # --- Preserve user-added links/joints from existing chain ---
+    user_links: list[ChainLink] = []
+    user_joints: list[ChainJoint] = []
+    if existing_chain_path.exists():
+        existing = load_chain_yaml(existing_chain_path)
+        user_links = [lk for lk in existing.links if lk.user_added]
+        user_joints = [jt for jt in existing.joints if jt.user_added]
+        if user_links or user_joints:
+            messages.append(
+                f"\nPreserved {len(user_links)} user-added link(s)"
+                f" and {len(user_joints)} user-added joint(s)"
+            )
+
+    links.extend(user_links)
+    joints.extend(user_joints)
+
+    chain = Chain(
+        robot_name=summary.robot_name,
+        dh_params=dh_params_dict if dh_params_dict else None,
+        links=links,
+        joints=joints,
+    )
+
+    # --- Final validation ---
+    if len(joints) != dof:
+        messages.append(
+            f"\n  WARNING: Generated {len(joints)} joints but specs say DOF={dof}"
+        )
+
+    return chain, messages

--- a/tests/test_chain_builder.py
+++ b/tests/test_chain_builder.py
@@ -1,0 +1,210 @@
+"""Tests for the chain_builder module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_arm_sim.analyze.chain_builder import (
+    _compute_axis_from_connections,
+    _compute_origin_from_connections,
+    _deg_to_rad,
+    _extract_link_number,
+    _is_numbered_naming,
+    _mm_to_m,
+    _order_parts_numbered,
+    build_chain,
+)
+from robot_arm_sim.models.models import ConnectionPoint, PartAnalysis
+
+# --- Unit tests for helpers ---
+
+
+class TestHelpers:
+    def test_deg_to_rad(self):
+        assert _deg_to_rad(180) == pytest.approx(3.1416, abs=1e-4)
+        assert _deg_to_rad(-90) == pytest.approx(-1.5708, abs=1e-4)
+        assert _deg_to_rad(0) == 0.0
+
+    def test_mm_to_m(self):
+        assert _mm_to_m(1000) == 1.0
+        assert _mm_to_m(89.159) == pytest.approx(0.089159)
+
+    def test_extract_link_number(self):
+        assert _extract_link_number("base") == 0
+        assert _extract_link_number("base_link") == 0
+        assert _extract_link_number("link_1") == 1
+        assert _extract_link_number("link_5") == 5
+        assert _extract_link_number("A3") == 3
+        assert _extract_link_number("shoulder") is None
+
+    def test_is_numbered_naming(self):
+        assert _is_numbered_naming(["base_link", "link_1", "link_2"])
+        assert not _is_numbered_naming(["base", "shoulder", "upperarm"])
+        assert _is_numbered_naming(["A0", "A1", "A2"])
+
+    def test_order_parts_numbered(self):
+        assert _order_parts_numbered(["link_2", "base_link", "link_1"]) == [
+            "base_link",
+            "link_1",
+            "link_2",
+        ]
+
+
+# --- Connection point tests ---
+
+
+def _make_analysis(
+    proximal_pos: list[float] | None = None,
+    distal_pos: list[float] | None = None,
+    distal_axis: list[float] | None = None,
+) -> PartAnalysis:
+    """Create a minimal PartAnalysis with optional connection points."""
+    cps = []
+    if proximal_pos:
+        cps.append(
+            ConnectionPoint(
+                end="proximal",
+                position=proximal_pos,
+                axis=[0, 0, 1],
+                radius_mm=50,
+                method="test",
+            )
+        )
+    if distal_pos:
+        cps.append(
+            ConnectionPoint(
+                end="distal",
+                position=distal_pos,
+                axis=distal_axis or [0, 0, 1],
+                radius_mm=50,
+                method="test",
+            )
+        )
+    return PartAnalysis(
+        part_name="test",
+        source_file="test.stl",
+        format="binary_stl",
+        connection_points=cps,
+    )
+
+
+class TestConnectionPoints:
+    def test_origin_from_proximal_distal(self):
+        analysis = _make_analysis(
+            proximal_pos=[0, 0, 0],
+            distal_pos=[0, 0, 100],  # 100mm apart
+        )
+        msgs: list[str] = []
+        origin = _compute_origin_from_connections(analysis, msgs, "j1")
+        assert origin is not None
+        assert origin == [0.0, 0.0, 0.1]  # 100mm = 0.1m
+
+    def test_origin_no_proximal(self):
+        analysis = _make_analysis(distal_pos=[50, 0, 200])
+        msgs: list[str] = []
+        origin = _compute_origin_from_connections(analysis, msgs, "j1")
+        assert origin is not None
+        assert origin == [0.05, 0.0, 0.2]
+
+    def test_origin_no_connection_points(self):
+        analysis = _make_analysis()
+        msgs: list[str] = []
+        origin = _compute_origin_from_connections(analysis, msgs, "j1")
+        assert origin is None
+
+    def test_axis_from_distal(self):
+        analysis = _make_analysis(
+            distal_pos=[0, 0, 100],
+            distal_axis=[0, 1, 0],
+        )
+        axis = _compute_axis_from_connections(analysis)
+        assert axis == [0, 1, 0]
+
+    def test_axis_no_distal(self):
+        analysis = _make_analysis(proximal_pos=[0, 0, 0])
+        axis = _compute_axis_from_connections(analysis)
+        assert axis is None
+
+
+# --- Integration tests with real robot data ---
+
+
+class TestBuildChainUR5:
+    """Test build_chain against UR5 robot data."""
+
+    @pytest.fixture
+    def ur5_dir(self) -> Path:
+        return Path("robots/UR5")
+
+    def test_builds_chain(self, ur5_dir: Path):
+        if not ur5_dir.exists():
+            pytest.skip("UR5 robot data not available")
+        chain, messages = build_chain(ur5_dir)
+        assert chain.robot_name == "UR5"
+        assert len(chain.links) == 7  # 7 parts
+        assert len(chain.joints) == 6  # 6 DOF
+        assert chain.dh_params is not None
+
+    def test_joint_limits_converted(self, ur5_dir: Path):
+        if not ur5_dir.exists():
+            pytest.skip("UR5 robot data not available")
+        chain, _ = build_chain(ur5_dir)
+        for joint in chain.joints:
+            assert joint.limits is not None
+            # UR5 has ±360° limits
+            assert joint.limits[0] == pytest.approx(-6.2832, abs=0.01)
+
+    def test_flags_semantic_ordering(self, ur5_dir: Path):
+        if not ur5_dir.exists():
+            pytest.skip("UR5 robot data not available")
+        _, messages = build_chain(ur5_dir)
+        assert any("REVIEW" in m and "semantic" in m for m in messages)
+
+    def test_flags_alpha_rotations(self, ur5_dir: Path):
+        if not ur5_dir.exists():
+            pytest.skip("UR5 robot data not available")
+        _, messages = build_chain(ur5_dir)
+        assert any("alpha=90" in m for m in messages)
+
+
+class TestBuildChainFANUC:
+    """Test build_chain against FANUC robot data."""
+
+    @pytest.fixture
+    def fanuc_dir(self) -> Path:
+        return Path("robots/FANUC-LRMate200iD")
+
+    def test_builds_chain(self, fanuc_dir: Path):
+        if not fanuc_dir.exists():
+            pytest.skip("FANUC robot data not available")
+        chain, messages = build_chain(fanuc_dir)
+        assert chain.robot_name == "FANUC-LRMate200iD"
+        assert len(chain.links) == 7
+        assert len(chain.joints) == 6
+
+    def test_numbered_ordering(self, fanuc_dir: Path):
+        if not fanuc_dir.exists():
+            pytest.skip("FANUC robot data not available")
+        chain, messages = build_chain(fanuc_dir)
+        names = [lk.name for lk in chain.links]
+        assert names == [
+            "base_link",
+            "link_1",
+            "link_2",
+            "link_3",
+            "link_4",
+            "link_5",
+            "link_6",
+        ]
+
+    def test_dh_fallback_origins(self, fanuc_dir: Path):
+        if not fanuc_dir.exists():
+            pytest.skip("FANUC robot data not available")
+        chain, _ = build_chain(fanuc_dir)
+        # Joint 1: d=330, a=50 → origin=[0.05, 0, 0.33]
+        j1 = chain.joints[0]
+        assert j1.origin is not None
+        assert j1.origin[0] == pytest.approx(0.05)
+        assert j1.origin[2] == pytest.approx(0.33)


### PR DESCRIPTION
## Summary

- Adds `build-chain` CLI command (`chain_builder.py`) that automates the deterministic parts of chain.yaml construction: part ordering, joint axes from bore detection, origins from connection points/DH fallback, joint limits (deg→rad), cross-validation, and user-added link preservation
- Updates make-robot skill step 03 to use the new command as the primary workflow, with LLM review for flagged items (semantic ordering, origin_rpy, combined parts)
- Adds 17 tests (unit + integration against UR5 and FANUC data)

## Test plan

- [x] `uv run tox -p` passes (all 4 environments: tests, type-checking, pre-commit, docs)
- [x] `build-chain --dry-run` tested on UR5 (connection-point mode) and FANUC (DH fallback mode)
- [ ] Verify `build-chain` produces a usable scaffold for a new robot

🤖 Generated with [Claude Code](https://claude.com/claude-code)