### PR TITLE
Harden Claude Code security in devcontainers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -z \"$REMOTE_CONTAINERS\" ]; then echo 'BLOCKED: This project requires the devcontainer. Please reopen in the devcontainer before using Claude Code.'; exit 2; fi"
+            "command": "if [ -z \"$REMOTE_CONTAINERS\" ]; then echo 'BLOCKED: This project requires the devcontainer. Please reopen in the devcontainer before using Claude Code.'; exit 2; fi; if ssh-add -l 2>/dev/null; then echo 'BLOCKED: SSH agent is available in the container. Set SSH_AUTH_SOCK= in devcontainer.json remoteEnv to disable it.'; exit 2; fi"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,11 +15,15 @@
       "Edit(*.claude/settings.local.json)",
       "Write(*.claude/settings.local.json)",
       "Bash(*settings.json*)",
-      "Bash(*settings.local.json*)"
+      "Bash(*settings.local.json*)",
+      "Bash(git push*)",
+      "Bash(git fetch*)",
+      "Bash(git pull*)",
+      "Bash(git clone*)",
+      "Bash(git remote*)",
+      "Bash(git ls-remote*)"
     ],
     "prompt": [
-      "Bash(git push --force *)",
-      "Bash(git push -f *)",
       "Bash(git reset --hard*)",
       "Bash(ssh *)",
       "Bash(scp *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,8 +9,17 @@
       "WebFetch(*)",
       "mcp__claude-in-chrome__*"
     ],
+    "deny": [
+      "Edit(*.claude/settings.json)",
+      "Write(*.claude/settings.json)",
+      "Edit(*.claude/settings.local.json)",
+      "Write(*.claude/settings.local.json)",
+      "Bash(*settings.json*)",
+      "Bash(*settings.local.json*)"
+    ],
     "prompt": [
       "Bash(git push --force *)",
+      "Bash(git push -f *)",
       "Bash(git reset --hard*)",
       "Bash(ssh *)",
       "Bash(scp *)",
@@ -19,7 +28,13 @@
       "Bash(wget --post* *)",
       "Bash(telnet *)",
       "Bash(mail *)",
-      "Bash(sendmail *)"
+      "Bash(sendmail *)",
+      "Bash(gh pr merge*)",
+      "Bash(gh gist create*)",
+      "Bash(gh api *)",
+      "Bash(pip install*)",
+      "Bash(npm install*)",
+      "Bash(uv add*)"
     ]
   },
   "hooks": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,8 @@
     "remoteEnv": {
         // Allow X11 apps to run inside the container
         "DISPLAY": "${localEnv:DISPLAY}",
+        // Disable SSH agent forwarding to prevent prompt injection from using SSH keys
+        "SSH_AUTH_SOCK": "",
         // Put things that allow it in the persistent cache
         "PRE_COMMIT_HOME": "/cache/pre-commit",
         "UV_CACHE_DIR": "/cache/uv",
@@ -63,10 +65,16 @@
             "source": "devcontainer-shared-cache",
             "target": "/cache",
             "type": "volume"
+        },
+        // Persist gh auth across container rebuilds with per-repo scoped PAT
+        {
+            "source": "gh-auth-${localWorkspaceFolderBasename}",
+            "target": "/root/.config/gh",
+            "type": "volume"
         }
     ],
     // Mount the parent as /workspaces so we can pip install peers as editable
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // After the container is created, recreate the venv then make pre-commit first run faster
-    "postCreateCommand": "uv venv --clear && uv sync && pre-commit install --install-hooks"
+    "postCreateCommand": "uv venv --clear && uv sync && pre-commit install --install-hooks && git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && git config --global url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,12 @@
         // Do the equivalent of "activate" the venv so we don't have to "uv run" everything
         "VIRTUAL_ENV": "/cache/venv-for${localWorkspaceFolder}",
         "PATH": "/cache/venv-for${localWorkspaceFolder}/bin:${containerEnv:PATH}",
-        // Use a container-local gitconfig so insteadOf rules don't leak to host
-        "GIT_CONFIG_GLOBAL": "/cache/container-gitconfig"
+        // Rewrite SSH git URLs to HTTPS without modifying ~/.gitconfig
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
+        "GIT_CONFIG_VALUE_0": "git@github.com:",
+        "GIT_CONFIG_KEY_1": "url.https://gitlab.diamond.ac.uk/.insteadOf",
+        "GIT_CONFIG_VALUE_1": "git@gitlab.diamond.ac.uk:"
     },
     "customizations": {
         "vscode": {
@@ -78,5 +82,5 @@
     // Mount the parent as /workspaces so we can pip install peers as editable
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // After the container is created, recreate the venv then make pre-commit first run faster
-    "postCreateCommand": "uv venv --clear && uv sync && pre-commit install --install-hooks && git config --file /cache/container-gitconfig url.'https://github.com/'.insteadOf 'git@github.com:' && git config --file /cache/container-gitconfig url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+    "postCreateCommand": "uv venv --clear && uv sync && pre-commit install --install-hooks"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,9 @@
         "UV_PROJECT_ENVIRONMENT": "/cache/venv-for${localWorkspaceFolder}",
         // Do the equivalent of "activate" the venv so we don't have to "uv run" everything
         "VIRTUAL_ENV": "/cache/venv-for${localWorkspaceFolder}",
-        "PATH": "/cache/venv-for${localWorkspaceFolder}/bin:${containerEnv:PATH}"
+        "PATH": "/cache/venv-for${localWorkspaceFolder}/bin:${containerEnv:PATH}",
+        // Use a container-local gitconfig so insteadOf rules don't leak to host
+        "GIT_CONFIG_GLOBAL": "/cache/container-gitconfig"
     },
     "customizations": {
         "vscode": {
@@ -76,5 +78,5 @@
     // Mount the parent as /workspaces so we can pip install peers as editable
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // After the container is created, recreate the venv then make pre-commit first run faster
-    "postCreateCommand": "uv venv --clear && uv sync && pre-commit install --install-hooks && git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && git config --global url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+    "postCreateCommand": "uv venv --clear && uv sync && pre-commit install --install-hooks && git config --file /cache/container-gitconfig url.'https://github.com/'.insteadOf 'git@github.com:' && git config --file /cache/container-gitconfig url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,13 +18,7 @@
         "UV_PROJECT_ENVIRONMENT": "/cache/venv-for${localWorkspaceFolder}",
         // Do the equivalent of "activate" the venv so we don't have to "uv run" everything
         "VIRTUAL_ENV": "/cache/venv-for${localWorkspaceFolder}",
-        "PATH": "/cache/venv-for${localWorkspaceFolder}/bin:${containerEnv:PATH}",
-        // Rewrite SSH git URLs to HTTPS without modifying ~/.gitconfig
-        "GIT_CONFIG_COUNT": "2",
-        "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
-        "GIT_CONFIG_VALUE_0": "git@github.com:",
-        "GIT_CONFIG_KEY_1": "url.https://gitlab.diamond.ac.uk/.insteadOf",
-        "GIT_CONFIG_VALUE_1": "git@gitlab.diamond.ac.uk:"
+        "PATH": "/cache/venv-for${localWorkspaceFolder}/bin:${containerEnv:PATH}"
     },
     "customizations": {
         "vscode": {

--- a/docs/explanations.md
+++ b/docs/explanations.md
@@ -6,6 +6,7 @@ Explanations of how it works and why it works that way.
 :maxdepth: 1
 
 explanations/building-with-claude
+explanations/claude-safety
 explanations/chrome-connector-workflow
 explanations/architecture
 explanations/inverse-kinematics

--- a/docs/explanations.md
+++ b/docs/explanations.md
@@ -7,6 +7,7 @@ Explanations of how it works and why it works that way.
 
 explanations/building-with-claude
 explanations/claude-safety
+explanations/claude-autonomous
 explanations/chrome-connector-workflow
 explanations/architecture
 explanations/inverse-kinematics

--- a/docs/explanations/building-with-claude.md
+++ b/docs/explanations/building-with-claude.md
@@ -63,9 +63,7 @@ The specific files mentioned here are for Claude Code, but the same features are
    - but includes risks
    - this project uses quite permissive settings, but only runs in a devcontainer to mitigate risks.
    - See `.claude/settings.json` in this project
-   - See {doc}`claude-safety` for a comprehensive security pattern covering
-     devcontainer isolation, scoped tokens, SSH agent controls, and
-     self-escalation prevention
+   - See {doc}`claude-safety` for a comprehensive security pattern covering devcontainer isolation, scoped tokens, SSH agent controls, and self-escalation prevention
 1. Use `CLAUDE.md` for durable project instructions:
    - Checked into the repo, so every session and every contributor gets the same baseline.
    - Good for build commands, coding conventions, and constraints that Claude should always follow.

--- a/docs/explanations/building-with-claude.md
+++ b/docs/explanations/building-with-claude.md
@@ -61,8 +61,11 @@ The specific files mentioned here are for Claude Code, but the same features are
 1. Manage permissions carefully.
    - giving more permission allows improved flow
    - but includes risks
-   - this project uses quite permissive settings, but only runs in a devcontainer to mitigate risks. It won't run outside of a devcontainer and it asks for permission on commands that may escape from the container.
+   - this project uses quite permissive settings, but only runs in a devcontainer to mitigate risks.
    - See `.claude/settings.json` in this project
+   - See {doc}`claude-safety` for a comprehensive security pattern covering
+     devcontainer isolation, scoped tokens, SSH agent controls, and
+     self-escalation prevention
 1. Use `CLAUDE.md` for durable project instructions:
    - Checked into the repo, so every session and every contributor gets the same baseline.
    - Good for build commands, coding conventions, and constraints that Claude should always follow.
@@ -513,6 +516,8 @@ deletions — [PR #33](https://github.com/gilesknap/robot-arm-sim/pull/33).
 
 ## Related documents
 
+- {doc}`claude-safety` — security pattern for running Claude Code
+  autonomously in devcontainers
 - {doc}`chrome-connector-workflow` — a detailed walkthrough of using the
   Chrome connector and camera skills to debug the end-effector
 - {doc}`implementation-plan` — the original plan written before any code

--- a/docs/explanations/claude-autonomous.md
+++ b/docs/explanations/claude-autonomous.md
@@ -1,0 +1,146 @@
+# Running Claude Code Autonomously in Containers
+
+This document describes how to run Claude Code in a fully autonomous mode
+(no human in the loop) inside an isolated container. For the interactive
+devcontainer pattern where a human reviews prompts, see
+{doc}`claude-safety`.
+
+```{contents}
+:local:
+:depth: 2
+```
+
+---
+
+## Overview
+
+When Claude runs unattended — in CI pipelines, scheduled tasks, or
+long-running autonomous sessions — the permission prompt system cannot
+provide safety because nobody is there to review. Instead, the
+**container itself** becomes the security boundary:
+
+- A dedicated throwaway container with only the credentials Claude needs
+- Network access restricted to an allowlist of hosts
+- `--dangerously-skip-permissions` enables full autonomy inside the sandbox
+
+This is cleaner than layering security on top of a VS Code devcontainer,
+which injects its own credential helpers and SSH agents that then need to
+be suppressed.
+
+---
+
+## Container setup
+
+Run Claude in a dedicated container with a scoped GitHub PAT as the only
+credential. Use Podman (or Docker) to create an ephemeral environment:
+
+```bash
+podman run --rm \
+  -e ANTHROPIC_API_KEY \
+  -e GH_TOKEN=<scoped-pat> \
+  -e HTTPS_PROXY=http://host.containers.internal:8888 \
+  -e HTTP_PROXY=http://host.containers.internal:8888 \
+  -e NO_PROXY=localhost,127.0.0.1 \
+  -v $(pwd):/workspace:Z \
+  <image> \
+  claude --dangerously-skip-permissions -p "do the task"
+```
+
+Key properties:
+
+- **Ephemeral** — `--rm` destroys the container after the task completes
+- **No SSH agent** — no keys are mounted or forwarded
+- **No VS Code credential helper** — this is not a devcontainer, so there
+  is no OAuth token injection
+- **Scoped PAT** — the `GH_TOKEN` is a fine-grained PAT with access only
+  to the repositories Claude needs (see {doc}`claude-safety` Layer 3 for
+  PAT setup)
+
+---
+
+## Restricting network access with a filtering proxy
+
+`--network=none` would block all network access including the GitHub API,
+so it is too restrictive. Instead, run a filtering forward proxy on the
+host that only allows connections to specific domains.
+
+### Why not iptables?
+
+- GitHub's IP ranges change frequently — maintaining CIDR allowlists is
+  fragile
+- Rootless Podman cannot manipulate iptables without `--cap-add=NET_ADMIN`
+- Domain-based filtering at the proxy layer is simpler and more
+  maintainable
+
+### tinyproxy setup
+
+Install tinyproxy on the host and create a configuration that denies all
+traffic by default, then allowlists specific domains.
+
+**`/etc/tinyproxy/tinyproxy.conf`:**
+
+```ini
+Port 8888
+Listen 127.0.0.1
+
+# Default deny — only domains in the filter list are allowed
+FilterDefaultDeny Yes
+Filter "/etc/tinyproxy/allow.list"
+```
+
+**`/etc/tinyproxy/allow.list`** (regex patterns, one per line):
+
+```text
+^api\.github\.com$
+^github\.com$
+^uploads\.github\.com$
+```
+
+Add any other domains Claude needs (e.g., `^pypi\.org$`,
+`^files\.pythonhosted\.org$` for pip installs).
+
+Start the proxy:
+
+```bash
+tinyproxy -c /etc/tinyproxy/tinyproxy.conf
+```
+
+### Connecting the container to the proxy
+
+Rootless Podman containers can reach the host via
+`host.containers.internal`. The proxy environment variables in the
+`podman run` command above route all HTTP/HTTPS traffic through tinyproxy:
+
+```bash
+-e HTTPS_PROXY=http://host.containers.internal:8888
+-e HTTP_PROXY=http://host.containers.internal:8888
+-e NO_PROXY=localhost,127.0.0.1
+```
+
+Any connection attempt to a domain not in the allowlist will be rejected
+by tinyproxy.
+
+---
+
+## Comparison with the interactive pattern
+
+| Aspect | Interactive devcontainer | Autonomous container |
+|--------|------------------------|---------------------|
+| Human in the loop | Yes — reviews prompts | No |
+| Permission model | allow/deny/prompt rules | `--dangerously-skip-permissions` |
+| Security boundary | Harness rules + scoped PAT | Container + network policy |
+| VS Code integration | Yes (credential helper present) | No (standalone container) |
+| Network restriction | None (accepted risk) | Proxy allowlist |
+| Lifetime | Long-lived development session | Ephemeral per-task |
+
+---
+
+## Checklist
+
+Before running Claude autonomously:
+
+1. Fine-grained PAT created and scoped to required repositories only
+2. tinyproxy running on host with domain allowlist
+3. Container image includes `claude`, `gh`, and project dependencies
+4. Branch protection rules enabled on the target repository
+5. No SSH keys, Docker sockets, or broad tokens mounted into the container

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -199,15 +199,19 @@ Disable SSH agent forwarding and force git to use HTTPS:
 ```json
 "remoteEnv": {
   "SSH_AUTH_SOCK": "",
-  "GIT_CONFIG_GLOBAL": "/cache/container-gitconfig"
-},
-"postCreateCommand": "... && git config --file /cache/container-gitconfig url.'https://github.com/'.insteadOf 'git@github.com:' && git config --file /cache/container-gitconfig url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+  "GIT_CONFIG_COUNT": "2",
+  "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
+  "GIT_CONFIG_VALUE_0": "git@github.com:",
+  "GIT_CONFIG_KEY_1": "url.https://gitlab.diamond.ac.uk/.insteadOf",
+  "GIT_CONFIG_VALUE_1": "git@gitlab.diamond.ac.uk:"
+}
 ```
 
-The `GIT_CONFIG_GLOBAL` environment variable points git at a container-local
-config file. This is important — using `--global` would write to `~/.gitconfig`
-which VS Code shares with the host, breaking SSH-based git workflows outside
-the devcontainer.
+The `GIT_CONFIG_COUNT`/`KEY`/`VALUE` environment variables inject git config
+at the environment level without modifying any config file. This is important
+— writing to `~/.gitconfig` (via `--global`) would leak to the host and break
+SSH-based git workflows outside the devcontainer. The env var approach also
+preserves the host's `user.name`, `user.email`, and other global git settings.
 
 This ensures:
 - **No SSH agent** in the container — SSH is simply unavailable
@@ -255,12 +259,15 @@ Combine all layers into your devcontainer configuration:
 {
   "remoteEnv": {
     "SSH_AUTH_SOCK": "",
-    "GIT_CONFIG_GLOBAL": "/cache/container-gitconfig"
+    "GIT_CONFIG_COUNT": "2",
+    "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
+    "GIT_CONFIG_VALUE_0": "git@github.com:",
+    "GIT_CONFIG_KEY_1": "url.https://gitlab.diamond.ac.uk/.insteadOf",
+    "GIT_CONFIG_VALUE_1": "git@gitlab.diamond.ac.uk:"
   },
   "mounts": [
     "source=gh-auth-${localWorkspaceFolderBasename},target=/root/.config/gh,type=volume"
-  ],
-  "postCreateCommand": "... && git config --file /cache/container-gitconfig url.'https://github.com/'.insteadOf 'git@github.com:' && git config --file /cache/container-gitconfig url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+  ]
 }
 ```
 

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -1,0 +1,273 @@
+# Securing Claude Code in Devcontainers
+
+This document describes a practical security pattern for running Claude Code
+autonomously in VS Code devcontainers. The goal is maximum autonomy with
+minimum blast radius — Claude should be able to read, write, build, test, and
+push code without constant permission prompts, while limiting the damage a
+prompt injection could cause.
+
+The pattern was developed for this project but is designed to be reusable
+across any Claude-enabled repository.
+
+```{contents}
+:local:
+:depth: 2
+```
+
+---
+
+## Threat model
+
+Claude Code operates with broad permissions to be productive. The primary
+threat is **prompt injection** — malicious instructions embedded in content
+Claude processes (GitHub issue bodies, fetched web pages, `CLAUDE.md` files in
+cloned repos, dependency READMEs). A successful injection could instruct Claude
+to:
+
+- Exfiltrate code or credentials to an external server
+- Push malicious code to repositories
+- SSH into remote machines
+- Modify its own permission rules to remove safety checks
+- Install malicious packages
+
+The key insight is that **Claude Code's permission rules (`.claude/settings.json`)
+are enforced by the harness, not by the LLM**. Claude cannot "decide" to ignore
+them. However, the pattern matching on Bash commands is fragile — a
+sophisticated injection can craft commands that achieve the same effect while
+evading the patterns. Therefore:
+
+- **Permission rules** are useful as speed bumps for accidental misuse
+- **Server-side enforcement** (GitHub branch protection, scoped tokens,
+  container boundaries) is the real security boundary
+- **Removing assets from the container** (SSH keys, broad tokens) eliminates
+  entire classes of attack
+
+---
+
+## Layer 1: Devcontainer isolation
+
+Claude Code must only run inside a devcontainer. A `UserPromptSubmit` hook
+in `.claude/settings.json` enforces this:
+
+```json
+"hooks": {
+  "UserPromptSubmit": [{
+    "hooks": [{
+      "type": "command",
+      "command": "if [ -z \"$REMOTE_CONTAINERS\" ]; then echo 'BLOCKED: ...'; exit 2; fi"
+    }]
+  }]
+}
+```
+
+The devcontainer provides:
+
+- **Write access limited to `/workspaces/`** — all repos, all git-backed
+- **Read-only mounts** for organisation code that Claude should reference but
+  not modify
+- **No Docker socket** — Claude cannot escape to the host via Docker
+- **No raw SSH keys** — see [Layer 4](#layer-4-ssh-agent-and-git-transport)
+
+---
+
+## Layer 2: Permission rules in settings.json
+
+`.claude/settings.json` defines three permission tiers:
+
+### Allow (auto-execute)
+
+```json
+"allow": [
+  "Read", "Edit", "Write", "Bash(*)",
+  "WebSearch", "WebFetch(*)"
+]
+```
+
+These run without prompting. `Bash(*)` is intentionally broad — restricting
+it would cripple Claude's ability to build, test, and run code.
+
+### Deny (blocked entirely)
+
+```json
+"deny": [
+  "Edit(*.claude/settings.json)",
+  "Write(*.claude/settings.json)",
+  "Edit(*.claude/settings.local.json)",
+  "Write(*.claude/settings.local.json)",
+  "Bash(*settings.json*)",
+  "Bash(*settings.local.json*)"
+]
+```
+
+**This is critical.** Without deny rules on settings files, a prompt injection
+could edit `.claude/settings.json` to remove all `prompt` rules, then proceed
+unrestricted. The harness checks deny rules *before* executing the tool call
+that would modify them, so this is a bootstrap lock that cannot be
+self-removed.
+
+### Prompt (require user confirmation)
+
+```json
+"prompt": [
+  "Bash(git push --force *)",
+  "Bash(git push -f *)",
+  "Bash(git reset --hard*)",
+  "Bash(ssh *)", "Bash(scp *)", "Bash(rsync *)", "Bash(sftp *)",
+  "Bash(telnet *)", "Bash(mail *)", "Bash(sendmail *)",
+  "Bash(wget --post* *)",
+  "Bash(gh pr merge*)",
+  "Bash(gh gist create*)",
+  "Bash(gh api *)",
+  "Bash(pip install*)",
+  "Bash(npm install*)",
+  "Bash(uv add*)"
+]
+```
+
+These are **speed bumps, not security boundaries**. A sophisticated injection
+can evade pattern matching (e.g., `bash -c "ssh ..."` bypasses
+`Bash(ssh *)`). But they catch accidental misuse and naive injection attempts.
+
+The rules gate:
+- **Destructive git operations** — force push, hard reset
+- **Network escape** — SSH, SCP, mail, POST requests
+- **Destructive GitHub operations** — merging PRs, creating gists, raw API calls
+- **Supply chain** — installing arbitrary packages
+
+---
+
+## Layer 3: Scoped GitHub/GitLab tokens
+
+The default `gh` OAuth token grants access to **all organisations and
+repositories**. Replace it with a fine-grained Personal Access Token (PAT)
+scoped to only the repositories Claude needs.
+
+### GitHub fine-grained PAT setup
+
+1. GitHub → Settings → Developer settings → Fine-grained personal access tokens
+2. **Repository access:** "Only select repositories" — pick the repos for this
+   devcontainer
+3. **Permissions:**
+   - Contents: Read and write
+   - Pull requests: Read and write
+   - Issues: Read and write
+   - Metadata: Read (required)
+   - **Do NOT grant:** Administration, Actions/workflow, or org-level permissions
+4. **Expiration:** 30–90 days (rotate regularly)
+5. Authenticate in the devcontainer: `gh auth login`
+
+### GitLab PAT setup
+
+1. GitLab → Preferences → Access Tokens
+2. Scope to specific projects/groups
+3. Authenticate: `git config --global credential.helper store` and use the
+   token for HTTPS operations
+
+### Persisting tokens across container rebuilds
+
+Use a named Docker volume per devcontainer so you only authenticate once:
+
+```json
+"mounts": [
+  "source=gh-auth-${localWorkspaceFolderBasename},target=/root/.config/gh,type=volume"
+]
+```
+
+Each devcontainer gets its own volume with its own scoped PAT. A compromised
+container can only access its own repository, not others.
+
+---
+
+## Layer 4: SSH agent and git transport
+
+### The problem
+
+VS Code automatically forwards the host's SSH agent into devcontainers. This
+means Claude can use your SSH keys to:
+
+- Push to **any** git repo your keys have access to (bypassing PAT scoping)
+- SSH into **any** remote machine your keys are authorised on
+
+The keys themselves aren't in the container (agent forwarding means the key
+material stays on the host), so they can't be exfiltrated. But they can be
+**used live** during the session.
+
+### The fix
+
+Disable SSH agent forwarding and force git to use HTTPS:
+
+```json
+"remoteEnv": {
+  "SSH_AUTH_SOCK": ""
+},
+"postCreateCommand": "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && git config --global url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+```
+
+This ensures:
+- **No SSH agent** in the container — SSH is simply unavailable
+- **Git uses HTTPS** — authenticated by the scoped PAT, not SSH keys
+- **You can still SSH from your host terminal** when needed — outside Claude's
+  reach
+
+---
+
+## Layer 5: Accepted risks
+
+Some risks are accepted as pragmatic trade-offs:
+
+### Network egress (data exfiltration)
+
+The container has unrestricted internet access. A sophisticated injection
+could exfiltrate code via `curl` or `WebFetch`. This risk is accepted because:
+
+- The workspace contains only code, all backed up in git
+- Read-only organisation mounts contain code only, no secrets
+- SSH keys are not present (agent forwarding is disabled)
+- GitHub/GitLab tokens are scoped and short-lived
+- Network allowlisting would restrict the developer's interactive use of the
+  container
+
+### Bash pattern evasion
+
+The `prompt` rules use pattern matching that can be bypassed by wrapping
+commands in `bash -c "..."`, scripts, or other indirection. This is accepted
+because:
+
+- The deny rules on settings files prevent self-escalation
+- Server-side enforcement (branch protection, scoped tokens) provides the
+  real boundary
+- The prompt rules still catch the majority of accidental and naive cases
+
+---
+
+## Complete devcontainer.json snippet
+
+Combine all layers into your devcontainer configuration:
+
+```json
+{
+  "remoteEnv": {
+    "SSH_AUTH_SOCK": ""
+  },
+  "mounts": [
+    "source=gh-auth-${localWorkspaceFolderBasename},target=/root/.config/gh,type=volume"
+  ],
+  "postCreateCommand": "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && git config --global url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+}
+```
+
+And the `.claude/settings.json` template is in this project's
+`.claude/settings.json`.
+
+---
+
+## Summary
+
+| Layer | What it protects against | Enforcement |
+|-------|------------------------|-------------|
+| Devcontainer | Host filesystem access | Container isolation |
+| Deny rules on settings | Self-escalation of permissions | Harness (bootstrap lock) |
+| Prompt rules | Accidental destructive commands | Harness (speed bump) |
+| Scoped PAT | Access to unrelated repos/orgs | GitHub/GitLab server-side |
+| No SSH agent | SSH to remote machines, git via SSH | Container config |
+| Git HTTPS rewrite | Bypassing PAT via SSH git remotes | Git config |

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -46,19 +46,26 @@ evading the patterns. Therefore:
 
 ## Layer 1: Devcontainer isolation
 
-Claude Code must only run inside a devcontainer. A `UserPromptSubmit` hook
-in `.claude/settings.json` enforces this:
+Claude Code must only run inside a devcontainer, and the container must not
+have SSH keys available. A `UserPromptSubmit` hook in `.claude/settings.json`
+checks both conditions on every prompt:
 
 ```json
 "hooks": {
   "UserPromptSubmit": [{
     "hooks": [{
       "type": "command",
-      "command": "if [ -z \"$REMOTE_CONTAINERS\" ]; then echo 'BLOCKED: ...'; exit 2; fi"
+      "command": "if [ -z \"$REMOTE_CONTAINERS\" ]; then echo 'BLOCKED: ...'; exit 2; fi; if ssh-add -l 2>/dev/null; then echo 'BLOCKED: SSH agent is available...'; exit 2; fi"
     }]
   }]
 }
 ```
+
+The first check verifies the `$REMOTE_CONTAINERS` environment variable is
+set (only present inside a VS Code devcontainer). The second check verifies
+that `ssh-add -l` **fails** — if it succeeds, SSH keys are reachable and the
+session is blocked. This catches cases where `SSH_AUTH_SOCK` was not cleared
+or was re-enabled.
 
 The devcontainer provides:
 

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -178,6 +178,8 @@ container can only access its own repository, not others.
 
 ---
 
+(layer-4-ssh-agent-and-git-transport)=
+
 ## Layer 4: SSH agent and git transport
 
 ### The problem

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -198,14 +198,21 @@ Disable SSH agent forwarding and force git to use HTTPS:
 
 ```json
 "remoteEnv": {
-  "SSH_AUTH_SOCK": ""
+  "SSH_AUTH_SOCK": "",
+  "GIT_CONFIG_GLOBAL": "/cache/container-gitconfig"
 },
-"postCreateCommand": "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && git config --global url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+"postCreateCommand": "... && git config --file /cache/container-gitconfig url.'https://github.com/'.insteadOf 'git@github.com:' && git config --file /cache/container-gitconfig url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
 ```
+
+The `GIT_CONFIG_GLOBAL` environment variable points git at a container-local
+config file. This is important — using `--global` would write to `~/.gitconfig`
+which VS Code shares with the host, breaking SSH-based git workflows outside
+the devcontainer.
 
 This ensures:
 - **No SSH agent** in the container — SSH is simply unavailable
 - **Git uses HTTPS** — authenticated by the scoped PAT, not SSH keys
+- **Config stays in the container** — host git workflows are unaffected
 - **You can still SSH from your host terminal** when needed — outside Claude's
   reach
 
@@ -247,12 +254,13 @@ Combine all layers into your devcontainer configuration:
 ```json
 {
   "remoteEnv": {
-    "SSH_AUTH_SOCK": ""
+    "SSH_AUTH_SOCK": "",
+    "GIT_CONFIG_GLOBAL": "/cache/container-gitconfig"
   },
   "mounts": [
     "source=gh-auth-${localWorkspaceFolderBasename},target=/root/.config/gh,type=volume"
   ],
-  "postCreateCommand": "git config --global url.'https://github.com/'.insteadOf 'git@github.com:' && git config --global url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
+  "postCreateCommand": "... && git config --file /cache/container-gitconfig url.'https://github.com/'.insteadOf 'git@github.com:' && git config --file /cache/container-gitconfig url.'https://gitlab.diamond.ac.uk/'.insteadOf 'git@gitlab.diamond.ac.uk:'"
 }
 ```
 

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -1,10 +1,16 @@
 # Securing Claude Code in Devcontainers
 
 This document describes a practical security pattern for running Claude Code
-autonomously in VS Code devcontainers. The goal is maximum autonomy with
-minimum blast radius — Claude should be able to read, write, build, test, and
-push code without constant permission prompts, while limiting the damage a
-prompt injection could cause.
+**interactively** in VS Code devcontainers — a human is present and reviews
+permission prompts. The goal is maximum autonomy with minimum blast radius:
+Claude should be able to read, write, build, test, and push code without
+constant permission prompts, while limiting the damage a prompt injection
+could cause.
+
+For **fully autonomous** use (CI pipelines, unattended sessions), where no
+human is reviewing prompts, see {doc}`claude-autonomous` which uses a
+dedicated container with network restrictions as the security boundary
+instead.
 
 The pattern was developed for this project but is designed to be reusable
 across any Claude-enabled repository.

--- a/docs/explanations/claude-safety.md
+++ b/docs/explanations/claude-safety.md
@@ -66,7 +66,7 @@ The devcontainer provides:
 - **Read-only mounts** for organisation code that Claude should reference but
   not modify
 - **No Docker socket** — Claude cannot escape to the host via Docker
-- **No raw SSH keys** — see [Layer 4](#layer-4-ssh-agent-and-git-transport)
+- **No raw SSH keys** — see [Layer 4](#layer-4-git-network-operations)
 
 ---
 
@@ -95,22 +95,36 @@ it would cripple Claude's ability to build, test, and run code.
   "Edit(*.claude/settings.local.json)",
   "Write(*.claude/settings.local.json)",
   "Bash(*settings.json*)",
-  "Bash(*settings.local.json*)"
+  "Bash(*settings.local.json*)",
+  "Bash(git push*)",
+  "Bash(git fetch*)",
+  "Bash(git pull*)",
+  "Bash(git clone*)",
+  "Bash(git remote*)",
+  "Bash(git ls-remote*)"
 ]
 ```
 
-**This is critical.** Without deny rules on settings files, a prompt injection
-could edit `.claude/settings.json` to remove all `prompt` rules, then proceed
-unrestricted. The harness checks deny rules *before* executing the tool call
-that would modify them, so this is a bootstrap lock that cannot be
-self-removed.
+**Settings file protection is critical.** Without deny rules on settings
+files, a prompt injection could edit `.claude/settings.json` to remove all
+`prompt` rules, then proceed unrestricted. The harness checks deny rules
+*before* executing the tool call that would modify them, so this is a
+bootstrap lock that cannot be self-removed.
+
+**Git network commands are denied, not prompted.** VS Code's devcontainer
+credential helper injects the host's broad GitHub OAuth token into every
+container. Any `git push/fetch/pull` command authenticates with this token,
+bypassing the scoped PAT in Layer 3. These commands are denied rather than
+prompted because prompt rules offer an "always allow in this project" button
+— users will inevitably click it, silently re-opening the OAuth token leak.
+Claude should use `gh` CLI commands instead (see
+[Layer 4](#layer-4-git-network-operations)), which authenticate with the
+scoped fine-grained PAT.
 
 ### Prompt (require user confirmation)
 
 ```json
 "prompt": [
-  "Bash(git push --force *)",
-  "Bash(git push -f *)",
   "Bash(git reset --hard*)",
   "Bash(ssh *)", "Bash(scp *)", "Bash(rsync *)", "Bash(sftp *)",
   "Bash(telnet *)", "Bash(mail *)", "Bash(sendmail *)",
@@ -129,7 +143,7 @@ can evade pattern matching (e.g., `bash -c "ssh ..."` bypasses
 `Bash(ssh *)`). But they catch accidental misuse and naive injection attempts.
 
 The rules gate:
-- **Destructive git operations** — force push, hard reset
+- **Destructive git operations** — hard reset
 - **Network escape** — SSH, SCP, mail, POST requests
 - **Destructive GitHub operations** — merging PRs, creating gists, raw API calls
 - **Supply chain** — installing arbitrary packages
@@ -178,49 +192,72 @@ container can only access its own repository, not others.
 
 ---
 
-(layer-4-ssh-agent-and-git-transport)=
+(layer-4-git-network-operations)=
 
-## Layer 4: SSH agent and git transport
+## Layer 4: Git network operations — use `gh`, not `git`
 
 ### The problem
 
-VS Code automatically forwards the host's SSH agent into devcontainers. This
-means Claude can use your SSH keys to:
+VS Code devcontainers automatically inject an HTTPS credential helper into
+the container's `~/.gitconfig`. This helper proxies the host's VS Code GitHub
+OAuth token — the same broad token that VS Code uses for PRs, settings sync,
+and other GitHub features. The injection happens at container start and cannot
+be disabled via `devcontainer.json`.
 
-- Push to **any** git repo your keys have access to (bypassing PAT scoping)
-- SSH into **any** remote machine your keys are authorised on
+This means that **any `git push`, `git fetch`, or `git pull` command
+authenticates with the host's full GitHub OAuth token**, which has access to
+all repositories and organisations the user can reach — completely bypassing
+the fine-grained PAT set up in Layer 3.
 
-The keys themselves aren't in the container (agent forwarding means the key
-material stays on the host), so they can't be exfiltrated. But they can be
-**used live** during the session.
+SSH agent forwarding is also disabled (`SSH_AUTH_SOCK: ""`), but the VS Code
+credential helper is the more insidious leak because it is invisible and
+cannot be opted out of.
 
-### The fix
+Overriding the credential helper via gitconfig or env vars is not a reliable
+fix: any file-based config change can be reverted by an attacker from inside
+the container.
 
-Disable SSH agent forwarding and force git to use HTTPS:
+### The compromise
 
-```json
-"remoteEnv": {
-  "SSH_AUTH_SOCK": "",
-  "GIT_CONFIG_COUNT": "2",
-  "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
-  "GIT_CONFIG_VALUE_0": "git@github.com:",
-  "GIT_CONFIG_KEY_1": "url.https://gitlab.diamond.ac.uk/.insteadOf",
-  "GIT_CONFIG_VALUE_1": "git@gitlab.diamond.ac.uk:"
-}
-```
+Since the VS Code credential helper cannot be removed, we take a different
+approach: **gate all network git operations behind prompt rules** and direct
+Claude to use `gh` CLI commands instead.
 
-The `GIT_CONFIG_COUNT`/`KEY`/`VALUE` environment variables inject git config
-at the environment level without modifying any config file. This is important
-— writing to `~/.gitconfig` (via `--global`) would leak to the host and break
-SSH-based git workflows outside the devcontainer. The env var approach also
-preserves the host's `user.name`, `user.email`, and other global git settings.
+The `gh` CLI authenticates with the fine-grained PAT from `gh auth login`
+(Layer 3), not the VS Code credential helper. Key commands:
 
-This ensures:
-- **No SSH agent** in the container — SSH is simply unavailable
-- **Git uses HTTPS** — authenticated by the scoped PAT, not SSH keys
-- **Config stays in the container** — host git workflows are unaffected
-- **You can still SSH from your host terminal** when needed — outside Claude's
-  reach
+- **Push and create PR:** `gh pr create` (pushes the branch via the GitHub API)
+- **View remote state:** `gh pr list`, `gh pr view`, `gh repo view`
+- **Fetch PR content:** `gh pr checkout`
+
+The deny rules in Layer 2 block `git push`, `git fetch`, `git pull`,
+`git clone`, `git remote`, and `git ls-remote`. Deny was chosen over prompt
+because prompt rules offer an "always allow" button that users will
+inevitably click, silently re-opening the OAuth token leak. Deny rules
+cannot be bypassed through the UI. The pattern matching itself is still
+evadable by a sufficiently crafted bash command — this remains a **speed
+bump, not a hard boundary** — but deny removes the most likely path to
+accidental re-enablement.
+
+### Why we removed the git HTTPS rewrite
+
+Earlier versions of this configuration used `GIT_CONFIG_COUNT` env vars to
+rewrite `git@github.com:` URLs to `https://github.com/`. This was intended to
+force git through the scoped PAT. However, the VS Code credential helper
+means HTTPS git operations still use the broad OAuth token, so the rewrite
+provided no security benefit. Many organisations use `insteadOf` rules in
+their host gitconfig to map HTTPS to SSH for normal development workflows;
+the env var overrides conflicted with these. Removing them simplifies the
+configuration and avoids confusing URL rewrite interactions.
+
+### What remains
+
+- **SSH agent forwarding is disabled** (`SSH_AUTH_SOCK: ""`) — SSH-based
+  access is unavailable
+- **`gh` CLI uses the scoped PAT** — all GitHub operations Claude should
+  perform go through `gh`
+- **`git` network commands require confirmation** — a speed bump that catches
+  accidental use of the broad OAuth token
 
 ---
 
@@ -260,12 +297,7 @@ Combine all layers into your devcontainer configuration:
 ```json
 {
   "remoteEnv": {
-    "SSH_AUTH_SOCK": "",
-    "GIT_CONFIG_COUNT": "2",
-    "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
-    "GIT_CONFIG_VALUE_0": "git@github.com:",
-    "GIT_CONFIG_KEY_1": "url.https://gitlab.diamond.ac.uk/.insteadOf",
-    "GIT_CONFIG_VALUE_1": "git@gitlab.diamond.ac.uk:"
+    "SSH_AUTH_SOCK": ""
   },
   "mounts": [
     "source=gh-auth-${localWorkspaceFolderBasename},target=/root/.config/gh,type=volume"
@@ -287,4 +319,4 @@ And the `.claude/settings.json` template is in this project's
 | Prompt rules | Accidental destructive commands | Harness (speed bump) |
 | Scoped PAT | Access to unrelated repos/orgs | GitHub/GitLab server-side |
 | No SSH agent | SSH to remote machines, git via SSH | Container config |
-| Git HTTPS rewrite | Bypassing PAT via SSH git remotes | Git config |
+| `gh` over `git` for network ops | VS Code OAuth token leak | Harness (speed bump) + convention |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,21 @@ commands = [
     ],
 ]
 
+[tool.tox.env.docs-autobuild]
+description = "Run docs with autobuild on change"
+commands = [
+    [
+        "sphinx-autobuild",
+        "--show-traceback",
+        "--watch",
+        "README.md",
+        "docs",
+        "build/html",
+        { replace = "posargs", default = [
+        ], extend = true },
+    ],
+]
+
 [tool.ruff]
 src = ["src", "tests"]
 line-length = 88

--- a/robot-arm-sim.code-workspace
+++ b/robot-arm-sim.code-workspace
@@ -4,7 +4,10 @@
 			"path": "."
 		},
 		{
-			"path": "../builder2ibek"
+			"path": "../tpi-k3s-ansible"
+		},
+		{
+			"path": "../dra-usbip-driver"
 		}
 	],
 	"settings": {}

--- a/scripts/gh-auth.sh
+++ b/scripts/gh-auth.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Authenticate gh CLI with a token without leaking it to bash history.
+# Usage: source scripts/gh-auth.sh   (or: bash scripts/gh-auth.sh)
+set -euo pipefail
+
+read -rsp "Paste GitHub token (input hidden): " token
+echo
+
+if [[ -z "$token" ]]; then
+  echo "Error: empty token" >&2
+  exit 1
+fi
+
+echo "$token" | gh auth login --with-token
+unset token
+
+echo "Done. Logged in as: $(gh api user -q .login)"


### PR DESCRIPTION
## Summary

- Add **deny rules** on settings files to prevent prompt injection from self-escalating permissions (bootstrap lock)
- **Deny git network commands** (`push`, `fetch`, `pull`, `clone`, `remote`, `ls-remote`) — Claude must use `gh` CLI instead, which authenticates with the scoped fine-grained PAT rather than VS Code's broad OAuth token
- Add **prompt rules** for destructive `gh` operations (`pr merge`, `gist create`, `api`), package installs (`pip`, `npm`, `uv add`), and `git reset --hard`
- **Disable SSH agent forwarding** in devcontainer to prevent key misuse
- Add **per-repo `gh` auth volume** for fine-grained PAT persistence across rebuilds
- Add `scripts/gh-auth.sh` for token setup without bash history leakage
- Add comprehensive **security documentation** (`docs/explanations/claude-safety.md`) covering threat model, layered defences, and complete devcontainer snippet
- Add **autonomous container isolation guide** (`docs/explanations/claude-autonomous.md`) covering `--dangerously-skip-permissions` in a dedicated container with tinyproxy domain allowlist for network restriction
- Clarify that `claude-safety.md` covers the **interactive** devcontainer pattern (human reviews prompts) and cross-reference the new autonomous doc

## Design decisions

- **`gh` over `git` for network ops:** VS Code injects an HTTPS credential helper that proxies the host's full GitHub OAuth token into every devcontainer. This cannot be disabled or reliably overridden from inside the container. Denying git network commands and using `gh` CLI (which uses the scoped PAT) is a compromise — not a hard boundary, but it removes the most likely path to accidental misuse
- **Deny rather than prompt for git network commands:** prompt rules offer an "always allow in this project" button that users will inevitably click, silently re-opening the OAuth token leak
- **Removed GIT_CONFIG_COUNT HTTPS rewrite:** provided no security benefit given the credential helper leak, and conflicted with host-side `insteadOf` rules used by many organisations
- **Interactive vs autonomous split:** the devcontainer safety doc assumes a human is present; fully autonomous use needs stronger isolation (dedicated container + network restrictions) rather than permission prompts nobody will see
- Deny rules are intentionally broad — catches even benign commands containing the target string, but prevents evasion
- Prompt rules are acknowledged as speed bumps, not security boundaries — server-side enforcement (scoped PATs, branch protection) is the real boundary

## Test plan

- [ ] Rebuild devcontainer and verify SSH agent is unavailable (`ssh-add -l`)
- [ ] Verify `gh auth status` works after `bash scripts/gh-auth.sh` with fine-grained PAT
- [ ] Verify Claude cannot run `git push` (deny rule blocks it)
- [ ] Verify `gh pr create` works and uses scoped PAT
- [ ] Verify Claude cannot edit settings files (deny rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)